### PR TITLE
Auto update system

### DIFF
--- a/docs/administration/Performing an update.md
+++ b/docs/administration/Performing an update.md
@@ -1,40 +1,31 @@
-# Performing an update - *user manual*
+# Performing a manual update - *user manual*
 
 At regular intervals throughout development, DSJAS will have updates rolled out to users. When an update occurs, DSJAS will detect it and inform administrators on the site that a new version is available. When this happens, it is very important to upgrade your version as soon as possible - allowing you to get the latest features and important security improvements.
 
-However, DSJAS does not have the capability to automatically update. To perform an update, you will need to download and install an update package manually.
+Most of the time, this can be performed automatically by DSJAS, which will obtain the update archive and extract it into the live server directory, thereby upgrading all files which reside in there. However, should this process fail for whatever reason, your site may be left in an intermediate or unusable state and will require intervention to upgrade. Additionally, some breaking changes may require additional actions, such as resetting the database or configuration files, which must be performed manually.
 
-## Obtaining an update package
+Should any of this occur, your best bet is to back up your data and perform a manual update.
 
-To download an update package for your release band and required version, click the *Download* button in the admin panel's update section. This will take you to the usual download page for DSJAS releases. Download the usual DSJAS package (zip file) from the required band. You can change your update band and opt out of pre-releases by downloading a stable release package. This will automatically opt your DSJAS install out of future pre-releases.
+## Upgrading the site
 
-## Backup your configuration
+Upgrading the site is only supported to be done automatically by the auto update system. Simply click "Update Now" on the update screen and follow any on screen instructions. If the update succeeds, proceed to the following steps.
 
-When installing the update package, your configuration will be overwritten and reset to default. Unless an update package specifically states that you **must** re-install the program, you should backup your configuration before continuing to install.
+If you are recovering from a partial upgrade, manually download the archive and extract the files into the DSJAS install directory. This will reset your site configuration but will recover a broken site from a partial upgrade. Should you wish to preserve your configuration files, simply copy the files you wish to preserve out of the DSJAS install folder before extracting the archive.
 
-You can do this by copying the following files to a separate, temporary location on your filesystem:
+## Upgrading your database
 
-* **In the root of the install:** Config.ini
-* **In the folder *admin/site/UI*:** config.ini
-* **In the folder *admin/site/modules*:** config.ini
-* **In the folder *admin/site/extensions*:** config.ini
+DSJAS will require that you reset your database such that no tables exist under the install database before resetting from an upgrade. This means that, without manual intervention, all data will be lost. This **will never** happen automatically and data is never erased by default. However, failure to upgrade the database of your site after an upgrade may result in malfunctions and loss of operation in hard to debug scenarios.
 
-You may also wish to backup the contents of the admin data directory (which contains non-essential admin data, such as notifications). This is located in the folder *admin/site/data*.
+To backup your database, use a tool such as PHPMyAdmin to backup the data from existing tables and save this as an SQL file on your computer. Then, drop all tables in the database. Save the SQL file from the first step for later reference. Do not yet do anything with this file.
 
-Please note that it is not necessary to back up your database or custom themes/modules/extensions; the update should not affect either of these in any way.
+## Upgrading your configuration
 
-## Installation
+It is unlikely that any configuration need be reset other than the configuration in the root. Simply delete this file and copy the default configuration from [here](https://github.com/DSJAS/DSJAS/blob/master/scripts/install/Config.ini). Any of the other configuration files in that directory on GitHub can also be used to reset the configs to defaults.
 
-Installing the update package should be relatively simple. After the zip file has completed download, you should extract the contained files to a temporary directory. The contained files will be all you need to update.
+When re-navigating to your site through a browser, it will have been reset to the first stage of installation. Simply follow through the installer and your upgrade will be complete.
 
-After these files have extracted, copy them to the existing DSJAS install directory, ensuring that whatever software you are using to copy them is overwriting the existing files.
+## Restoring your database
 
-**Do not yet navigate to DSJAS in a browser!** Your site will now be broken until you restore the configuration you backed up in the previous step.
+Execute the SQL backup scripts you saved in the database upgrade stage for each table you backed up. This should restore any data you had in the tables before the upgrade to the database.
 
-## Restore configuration
-
-Now, you can copy back the configuration files you backed up. This will restore all your personal settings. The files should be copied back to the locations you took them from. They **will overwrite something already there** - this is normal and is just overwriting the default settings shipped with the program.
-
-After you have done this, you can navigate to the site in your browser and everything should work fine. In most cases, your login state will be preserved too, meaning you will not have to sign in again.
-
-To verify that everything is working as expected and that there are no more updates to install, it is a good idea to check for updates using the update menu. It will inform you if there are any more updates required to install (sometimes this will happen and you will need to install multiple).
+If you encounter any issues doing this, the schema may have changed to the point where your data is no longer valid in the database. This is rare but, unfortunately, could occur occasionally. This is most likely to occur across major releases, but by no means always.

--- a/public/admin/settings/do-update.php
+++ b/public/admin/settings/do-update.php
@@ -108,6 +108,16 @@ try {
     err("Failed to copy upload archive to live server root: $e");
 }
 
+// Tell the administrator
+addAdministrationNotice("update_success", "DSJAS System Update Succeeded",
+    "A DSJAS system update was completed at " . date("H:i d M Y") . ". DSJAS was upgraded to v" . $u->toString() . " and is now the latest version. "
+    . "Your theme and module configurations have been reset to the default to avoid any incompatabilities with the new version of DSJAS.",
+
+    "/admin/settings/update.php",
+    "View Patch Notes",
+    ADMIN_NOTICE_SUCCESS
+);
+
 ?>
 
 <div class="alert alert-success">

--- a/public/admin/settings/do-update.php
+++ b/public/admin/settings/do-update.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of DSJAS
+ * Written and maintained by the DSJAS project.
+ *
+ * Copyright (C) 2020 - Ethan Marshall
+ *
+ * DSJAS is free software which is licensed and distributed under
+ * the terms of the MIT software licence.
+ * Exact terms can be found in the LICENCE file.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * above mentioned licence for specific details.
+ */
+
+require "../AdminBootstrap.php";
+
+require_once ABSPATH . INC . "Update.php";
+require_once ABSPATH . INC . "csrf.php";
+require_once ABSPATH . INC . "Administration.php";
+require_once ABSPATH . INC . "Util.php";
+
+ignore_user_abort(true); // Don't allow the user to cancel this install by closing the loading browser
+set_time_limit(0); // Don't stop the script if it takes too long
+ob_start(); // Enable output buffering
+
+if (!isUpdateAvailable()) {
+    die("Already up to date");
+}
+
+// Preliminary info
+$major = getMajorVersion();
+$minor = getMinorVersion();
+$patch = getPatchVersion();
+$band = getUpdateBand();
+
+$u = getLatestAvailableVersion($band);
+$uMajor = $u[0];
+$uMinor = $u[1];
+$uPatch = $u[2];
+
+// Download update archive
+$archiveURL = getArchiveLocation($uMajor, $uMinor, $uPatch, $band);
+
+Requests::register_autoloader();
+try {
+    $downloadRequest = Requests::get($archiveURL);
+    $fileContent = $downloadRequest->body;
+} catch (Requests_Exception $e) {
+    die("Download of update archive failed: $e");
+}
+
+if (!$downloadRequest->success || $downloadRequest->status_code != 200)
+{
+    die("Download of update archive failed");
+}
+
+// Dump file
+$archive = tempnam("", "dsjasupdate");
+$fh = fopen($archive, "w");
+fputs($fh, $fileContent);
+
+// Make Phar detect it
+$newArchive = "$archive.tar.gz";
+fclose($fh);
+rename($archive, $newArchive);
+
+// Extract tar file
+$tarPath = "$archive.tar";
+$tar = new PharData($newArchive);
+$tar->decompress();
+
+// Finally, get sources
+$src = new PharData($tarPath);
+$src->extractTo(dirname($archive), null, true);

--- a/public/admin/settings/do-update.php
+++ b/public/admin/settings/do-update.php
@@ -54,8 +54,8 @@ if (!isUpdateAvailable()) {
 
 // Preliminary info
 $rel = getCurrentRelease();
-$u = getLatestAvailableVersion($rel->getBand());
-$url = $u->getDownload($rel->getBand());
+$u = getLatestAvailableVersion(getUpdateBand());
+$url = $u->getDownload(getUpdateBand());
 
 if ($url === false)
 {

--- a/public/admin/settings/do-update.php
+++ b/public/admin/settings/do-update.php
@@ -86,10 +86,26 @@ if ($zip->open($archive, ZipArchive::RDONLY) !== true)
 }
 $zip->extractTo(ABSPATH . "/uploads/update/");
 
+// Copy out configuration files
+if (copy(ABSPATH . "/Config.ini", ABSPATH . "/uploads/update/Config.ini") === false)
+{
+    err("Failed to copy out current configuration");
+}
+
+// Finally, copy out to source tree
+try {
+    recurseCopy(ABSPATH . "/uploads/update/", ABSPATH);
+} catch (Exception $ex) {
+    err("Failed to copy upload archive to live server root: $e");
+}
+
 ?>
 
 <div class="alert alert-success">
     <p>
         <strong>Update Success</strong> DSJAS has been upgraded to version <?= $u->toString() ?>.
+        Your main configuration has been preserved, but theme and module configurations have been reset in case of incompatibility with the new version.
+
+        <br>
         <a href="/admin/settings/update.php">Return to Update Page</a>
 </div>

--- a/public/admin/settings/do-update.php
+++ b/public/admin/settings/do-update.php
@@ -36,6 +36,15 @@ function err($error)
         </p>
     </div>
 <?php
+
+    addAdministrationNotice("update_failure", "DSJAS System Update Failed",
+        "A DSJAS system update was attempted at " . date("H:i d/M/Y") . ". A fatal error ocurred and no upgrade was performed. The current system version was unaffected. "
+        . "Error reason: " . $error,
+
+        "/admin/settings/update.php",
+        "Update Options",
+        ADMIN_NOTICE_WARNING
+    );
     die();
 }
 

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -134,7 +134,7 @@ function showAheadWarning()
 
                     <div class="btn-group">
                         <a class="btn btn-primary" href="/admin/settings/do-update.php">Update now</a>
-                        <a class="btn btn-secondary" href="https://github.com/DSJAS/DSJAS/blob/master/docs/administration/Performing%20an%20update.md">More information</a>
+                        <a class="btn btn-secondary" href="<?= getLatestAvailableVersion($band)->getLink() ?>">More information</a>
                     </div>
             <?php } else { ?>
                 <h3 class="text-success">

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -207,11 +207,9 @@ function showAheadWarning()
             <table class="table table-dark table-bordered">
                 <tr>
                     <td class="admin-info-key">Opted in to pre-release</td>
-                    <td class="admin-info-value"><?php if ($insiderBand) {
-                                                        echo ("Yes");
-} else {
-                                                     echo ("No");
-                                                 } ?></td>
+                    <td class="admin-info-value">
+                        <?= ($insiderBand) ? "Yes" : "No" ?>
+                    </td>
                 </tr>
                 <tr>
                     <td class="admin-info-key">Your current release band</td>

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -107,10 +107,21 @@ function showAheadWarning()
 
                     <hr>
 
-                    <a class="text-secondary">DSJAS failed to contact the update server. It may be under maintainence or you may have reached your rate limit.
-                        Please try again in a few minutes. Rate limits normally take around half an hour to expire.</a>
+                    <?php if (isRateLimited()) { ?>
+                        <p class="text-secondary">
+                            <strong>GitHub API Rate Limit Reached</strong>
+                            You have reached the GitHub API rate limit. Please wait until <?= gmdate("g:i a m.d.y", getTimeoutExpire()) ?>
+                            and try again.
+                        </p>
+                    <?php } else { ?>
+                        <p class="text-secondary">
+                            <strong>Failed to Contact Update Server</strong>
+                            The releases API did not respond to the request or DSJAS could not reach the internet.
+                            Please check your server's internet connection and that GitHub is currently up correctly.
+                        </p>
+                    <?php }
 
-            <?php } else {
+            } else {
 
             if (isUpdateAvailable()) { ?>
                 <h3 class="text-warning">

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -40,8 +40,8 @@ if (isInsiderBand()) {
 
 function showAheadWarning()
 {
-    if (getCurrentRelease()->laterThanRelease(getLatestAvailableVersion($band)) &&
-        !getLatestAvailableVersion($band)->isDummy())
+    if (getCurrentRelease()->laterThanRelease(getLatestAvailableVersion(getUpdateBand())) &&
+        !getLatestAvailableVersion(getUpdateBand())->isDummy())
         return "";
     else
         return "d-none";

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -90,7 +90,7 @@ if (isInsiderBand()) {
                     <hr>
 
                     <div class="btn-group">
-                        <a class="btn btn-primary" href="https://github.com/DSJAS/DSJAS/releases">Download update</a>
+                        <a class="btn btn-primary" href="/admin/settings/do-update.php">Update now</a>
                         <a class="btn btn-secondary" href="https://github.com/DSJAS/DSJAS/blob/master/docs/administration/Performing%20an%20update.md">More information</a>
                     </div>
             <?php } else { ?>

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -85,8 +85,8 @@ function showAheadWarning()
         <h1 class="admin-header col col-offset-6">DSJAS Updates</h1>
 
         <div class="btn-toolbar mb-2 mb-md-0">
-            <p><strong>Your current version:</strong> <?php echo (getVersionString()); ?> <span class="badge <?php echo ($bandBadgeStyle); ?>">
-                    <?php echo ($band); ?></span></p>
+            <p><strong>Your current version:</strong> <?= getVersionString() ?> <span class="badge <?= $bandBadgeStyle ?>">
+                    <?= $band ?></span></p>
         </div>
     </div>
 
@@ -159,8 +159,8 @@ function showAheadWarning()
 
             <hr>
 
-            <p><strong>Current version:</strong> <?php echo (getVersionString()); ?></p>
-            <p><strong>Latest available version:</strong> <?php echo (getLatestAvailableVersion($band)->toString()); ?></p>
+            <p><strong>Current version:</strong> <?= getSemanticVersion() ?></p>
+            <p><strong>Latest available version:</strong> <?= getLatestAvailableVersion($band)->toString() ?></p>
         </div>
     </div>
 
@@ -173,11 +173,11 @@ function showAheadWarning()
             <table class="table table-dark table-bordered">
                 <tr>
                     <td class="admin-info-key">Current version:</td>
-                    <td class="admin-info-value"><?php echo (getSemanticVersion()); ?></td>
+                    <td class="admin-info-value"><?= getSemanticVersion() ?></td>
                 </tr>
                 <tr>
                     <td class="admin-info-key">Version name:</td>
-                    <td class="admin-info-value"><?php echo (getVersionName()); ?></td>
+                    <td class="admin-info-value"><?= getVersionName() ?></td>
                 </tr>
             </table>
 
@@ -215,7 +215,7 @@ function showAheadWarning()
                 </tr>
                 <tr>
                     <td class="admin-info-key">Your current release band</td>
-                    <td class="admin-info-value"><?php echo ($band); ?></td>
+                    <td class="admin-info-value"><?= $band ?></td>
                 </tr>
             </table>
         </div>

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -76,7 +76,8 @@ if (isInsiderBand()) {
 
                     <hr>
 
-                    <a class="text-secondary">DSJAS failed to contact the update server. It may be under maintainence or you may have reached your rate limit. Please try again in a few minutes.</a>
+                    <a class="text-secondary">DSJAS failed to contact the update server. It may be under maintainence or you may have reached your rate limit.
+                        Please try again in a few minutes. Rate limits normally take around half an hour to expire.</a>
 
             <?php } else {
 

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -50,6 +50,28 @@ if (isInsiderBand()) {
 
     <?php require ABSPATH . INC . "components/AdminSettingsNav.php"; ?>
 
+
+    <div class="modal fade" id="patchNotes" tabindex="-1" role="dialog">
+        <div class="modal-dialog modal-dialog-scrollable" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Patch Notes for <?= getVersionString() ?></h5>
+                    <button type="button" class="close" data-dismiss="modal">
+                        <span>&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>
+                        <?= getVersionDescription() ?>
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3 border-bottom">
         <h1 class="admin-header col col-offset-6">DSJAS Updates</h1>
 
@@ -127,13 +149,9 @@ if (isInsiderBand()) {
                     <td class="admin-info-key">Version name:</td>
                     <td class="admin-info-value"><?php echo (getVersionName()); ?></td>
                 </tr>
-                <tr>
-                    <td class="admin-info-key">Version description:</td>
-                    <td class="admin-info-value"><?php echo (getVersionDescription()); ?></td>
-                </tr>
             </table>
 
-            <a href="https://github.com/DSJAS/DSJAS/releases">Patch notes</a>
+            <a href="#" data-toggle="modal" data-target="#patchNotes">Patch notes</a>
         </div>
     </div>
 

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -40,7 +40,8 @@ if (isInsiderBand()) {
 
 function showAheadWarning()
 {
-    if (getCurrentRelease()->laterThanRelease(getLatestAvailableVersion($band)))
+    if (getCurrentRelease()->laterThanRelease(getLatestAvailableVersion($band)) &&
+        !getLatestAvailableVersion($band)->isDummy())
         return "";
     else
         return "d-none";

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -65,7 +65,7 @@ if (isInsiderBand()) {
         </div>
 
         <div class="card-body">
-            <?php if (getLatestAvailableVersion($band) == "0.0.0") { ?>
+            <?php if (getLatestAvailableVersion($band)->isDummy()) { ?>
 
 
                 <h3 class="text-danger">
@@ -76,7 +76,7 @@ if (isInsiderBand()) {
 
                     <hr>
 
-                    <a class="text-secondary">DSJAS failed to contact the update server. It may be under maintainence, down or your server may have lost internet connection</a>
+                    <a class="text-secondary">DSJAS failed to contact the update server. It may be under maintainence or you may have reached your rate limit. Please try again in a few minutes.</a>
 
             <?php } else {
 
@@ -107,7 +107,7 @@ if (isInsiderBand()) {
             <hr>
 
             <p><strong>Current version:</strong> <?php echo (getVersionString()); ?></p>
-            <p><strong>Latest available version:</strong> <?php echo (getLatestAvailableVersion($band)); ?></p>
+            <p><strong>Latest available version:</strong> <?php echo (getLatestAvailableVersion($band)->toString()); ?></p>
         </div>
     </div>
 

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -59,13 +59,6 @@ if (isInsiderBand()) {
         </div>
     </div>
 
-    <div class="alert alert-warning">
-        <p><strong>Attention:</strong> DSJAS does not yet contain an automatic updater. This means that you will need
-            to download and install updates yourself. For more information and specific instructions, please see the
-            <a href="https://github.com/DSJAS/DSJAS/blob/master/docs/administration/Performing%20an%20update.md">upgrade guide</a>.
-        </p>
-    </div>
-
     <div class="card bg-light admin-panel">
         <div class="card-header d-flex justify-content-between">
             <h3>Update status</h3>

--- a/public/admin/settings/update.php
+++ b/public/admin/settings/update.php
@@ -38,6 +38,14 @@ if (isInsiderBand()) {
     $bandBadgeStyle = "badge-success";
 }
 
+function showAheadWarning()
+{
+    if (getCurrentRelease()->laterThanRelease(getLatestAvailableVersion($band)))
+        return "";
+    else
+        return "d-none";
+}
+
 ?>
 
 <html>
@@ -126,6 +134,16 @@ if (isInsiderBand()) {
             <?php }
             } ?>
 
+
+            <span class="text-warning <?= showAheadWarning() ?>">
+                <br>
+
+                <svg class="bi bi-exclamation-triangle-fill" width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" d="M8.982 1.566a1.13 1.13 0 00-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5a.905.905 0 00-.9.995l.35 3.507a.552.552 0 001.1 0l.35-3.507A.905.905 0 008 5zm.002 6a1 1 0 100 2 1 1 0 000-2z" clip-rule="evenodd" />
+                </svg>
+
+                Local version is newer than latest available
+            </span>
 
             <hr>
 

--- a/public/include/Administration.php
+++ b/public/include/Administration.php
@@ -21,6 +21,15 @@ require_once "Util.php";
 
 require_once "vendor/requests/library/Requests.php";
 
+// Admin notice styles
+define("ADMIN_NOTICE_INFO", 0);
+define("ADMIN_NOTICE_PRIMARY", 1);
+define("ADMIN_NOTICE_SECONDARY", 2);
+define("ADMIN_NOTICE_WARNING", 3);
+define("ADMIN_NOTICE_DANGER", 4);
+define("ADMIN_NOTICE_SUCCESS", 5);
+define("ADMIN_NOTICE_DEFAULT", ADMIN_NOTICE_INFO);
+
 
 function getAdministrationNotices()
 {

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -87,7 +87,7 @@ class Release
         $this->id = $r["id"];
         $this->tag = $r["tag_name"];
         $this->name = $r["name"];
-        $this->notes = str_replace("\r\n", "<br>", $r["body"]);
+        $this->notes = $this->processPatchNotes($r["body"]);
         $this->pre = $r["prerelease"];
 
         $this->url = $r["url"];
@@ -113,6 +113,18 @@ class Release
         $this->is_stable = ($this->stable_zip != "");
         $this->is_beta = ($this->beta_zip != "");
         $this->is_alpha = ($this->alpha_zip != "");
+    }
+
+    private function processPatchNotes($notes)
+    {
+        $work = str_replace("\r\n", "<br>", $notes);
+
+        /* TODO: Header support (will need regex) */
+        /* $work = str_replace("#", "<h4>", $work); */
+        /* $work = str_replace("##", "<h5>", $work); */
+        /* $work = str_replace("###", "<h6>", $work); */
+
+        return $work;
     }
 
     public function getBand()

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -94,6 +94,24 @@ function getVersionString()
     return $ver;
 }
 
+function parseVersionString($version)
+{
+    $around = explode("-", $version);
+    $version = explode(".", $around[0]);
+
+    if (count($around) > 1) {
+        $band = $around[1];
+    } else {
+        $band = "";
+    }
+
+    if (count($version) != 3) {
+        $version = ["-1", "-1", "-1"];
+    }
+
+    return [$version[0], $version[1], $version[2], $band];
+}
+
 function getLatestAvailableVersion($band)
 {
     Requests::register_autoloader();
@@ -116,10 +134,16 @@ function isUpdateAvailable()
     $currentVersion = getVersionString();
     $latest = getLatestAvailableVersion(getUpdateBand());
 
-    $numericCurrent = (float) $currentVersion;
-    $numericLatest = (float) $latest;
+    $versions = parseVersionString($latest);
 
-    return $currentVersion < $latest;
+    if ((int)$versions[0] > (int)getMajorVersion()
+        || (int)$versions[1] > (int)getMinorVersion()
+        || (int)$versions[2] > (int)getPatchVersion()) {
+
+        return true;
+    } else {
+        return false;
+    }
 }
 
 function isInsiderBand()

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -87,7 +87,7 @@ class Release
         $this->id = $r["id"];
         $this->tag = $r["tag_name"];
         $this->name = $r["name"];
-        $this->notes = $r["body"];
+        $this->notes = str_replace("\r\n", "<br>", $r["body"]);
         $this->pre = $r["prerelease"];
 
         $this->url = $r["url"];
@@ -160,6 +160,21 @@ class Release
     public function getPatchNotes()
     {
         return $this->notes;
+    }
+
+    public function getLink()
+    {
+        return $this->url;
+    }
+
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
+    public function getAuthorLink()
+    {
+        return $this->author_url;
     }
 
     public function toString()

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -27,6 +27,8 @@ define("ARCHIVE_ENDPOINT", "https://github.com/DSJAS/DSJAS/archive");
  * performance, as the GitHub API is much slower than this page.
  */
 static $__current_release = null;
+static $__releases_cache = null;
+
 static $__version_information;
 
 static $dummy_release = [
@@ -292,6 +294,14 @@ function isRateLimited()
 /* Returns an array of Release objects parsed from the release API */
 function getReleases()
 {
+    global $__releases_cache;
+
+    /* return cached copy if available */
+    if ($__releases_cache != null && count($__releases_cache) != 0)
+        return $__releases_cache;
+
+
+    /* else hit API */
     Requests::register_autoloader();
 
     $decoded = [];
@@ -302,12 +312,12 @@ function getReleases()
         return [];
     }
 
-    $obj = [];
+    $__releases_cache = [];
     foreach ($decoded as $d) {
-        $obj[] = new Release($d);
+        $__releases_cache[] = new Release($d);
     }
 
-    return $obj;
+    return $__releases_cache;
 }
 
 function getCurrentRelease()

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -35,6 +35,7 @@ static $dummy_release = [
     "url" => "https://github.com/DSJAS/DSJAS/releases",
 
     "author" => array("login" => "ejv2", "url" => "https://github.com/ejv2"),
+    "assets" => array(["name" => "dummy asset"]),
 ];
 
 /*

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -383,18 +383,14 @@ function getLatestAvailableVersion($band)
 {
     $currentBand = getUpdateBand();
     $releases = getReleases();
-    $latest = getCurrentRelease();
+    $latest = new Release([0, 0, 1, "alpha"]);
 
     foreach ($releases as $r) {
         /* if any updates failed, return that */
         if ($r->isDummy())
             return $r;
 
-        if ($r->matchesBand($currentBand) &&
-            $r->laterThan(getMajorVersion(),
-                            getMinorVersion(),
-                            getPatchVersion()) &&
-            $r->laterThanRelease($latest)) {
+        if ($r->matchesBand($currentBand) && $r->laterThanRelease($latest)) {
             $latest = $r;
         }
     }

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -56,6 +56,7 @@ class Release
     private $pre;
 
     private $url;
+    private $human_url;
 
     private $author;
     private $author_url;
@@ -91,6 +92,7 @@ class Release
         $this->pre = $r["prerelease"];
 
         $this->url = $r["url"];
+        $this->human_url = $r["html_url"];
 
         $this->author = $r["author"]["login"];
         $this->author_url = $r["author"]["url"];
@@ -174,9 +176,14 @@ class Release
         return $this->notes;
     }
 
-    public function getLink()
+    public function getAPILink()
     {
         return $this->url;
+    }
+
+    public function getLink()
+    {
+        return $this->human_url;
     }
 
     public function getAuthor()

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -19,12 +19,201 @@
 require ABSPATH . INC . "vendor/requests/library/Requests.php";
 
 
-define("LATEST_UPDATE_ENDPOINT", "https://dsjas.github.io/update/DSJAS/latest-");
+define("RELEASES_ENDPOINT", "https://api.github.com/repos/DSJAS/DSJAS/releases");
 define("ARCHIVE_ENDPOINT", "https://github.com/DSJAS/DSJAS/archive");
 
 
 static $__version_information;
 
+static $dummy_release = [
+    "id" => 0,
+    "tag_name" => "0.0.0",
+    "name" => "",
+    "body" => "",
+    "prerelease" => true,
+
+    "url" => "https://github.com/DSJAS/DSJAS/releases",
+
+    "author" => array("login" => "ejv2", "url" => "https://github.com/ejv2"),
+];
+
+/*
+ * Release holds all the pertinent data for DSJAS updates as returned by the GitHub API.
+ * It is constructed from the associative array returned when parsing JSON from the API
+ * response.
+ */
+class Release
+{
+    private $id;
+    private $tag;
+    private $name;
+    private $notes;
+    private $pre;
+
+    private $url;
+
+    private $author;
+    private $author_url;
+
+    private $is_stable;
+    private $is_beta;
+    private $is_alpha;
+
+    private $stable_zip = "";
+    private $beta_zip = "";
+    private $alpha_zip = "";
+
+    /*
+     * Construct a new release object from the parsed JSON response $r.
+     */
+    public function __construct($r)
+    {
+        if ($r === null)
+            throw new InvalidArgumentException("cannot parse from NULL JSON response");
+        if (gettype($r) === "string") {
+            $this->tag = "0.0.0";
+            return;
+        }
+
+
+        $this->id = $r["id"];
+        $this->tag = $r["tag_name"];
+        $this->name = $r["name"];
+        $this->notes = $r["body"];
+        $this->pre = $r["prerelease"];
+
+        $this->url = $r["url"];
+
+        $this->author = $r["author"]["login"];
+        $this->author_url = $r["author"]["url"];
+
+        $assets = $r["assets"];
+        foreach ($assets as $a) {
+            switch ($a["name"]) {
+            case "DSJAS-release-alpha.zip":
+                $this->alpha_zip = $a["browser_download_url"];
+                break;
+            case "DSJAS-release-beta.zip":
+                $this->beta_zip = $a["browser_download_url"];
+                break;
+            case "DSJAS-release-stable.zip":
+                $this->stable_zip = $a["browser_download_url"];
+                break;
+            }
+        }
+
+        $this->is_stable = ($this->stable_zip != "");
+        $this->is_beta = ($this->beta_zip != "");
+        $this->is_alpha = ($this->alpha_zip != "");
+    }
+
+    public function getBand()
+    {
+        $segs = explode("-", $this->tag);
+
+        if (count($segs) == 1)
+            return "stable";
+
+        return $segs[1];
+    }
+
+    private function verseg($seg)
+    {
+        $halves = explode("-", $this->tag);
+        $first = $halves[0];
+
+        $segs = explode(".", $first);
+        if ($seg > count($segs))
+            return "0";
+
+        return $segs[$seg];
+    }
+
+    public function getMajor()
+    {
+        return $this->verseg(0);
+    }
+
+    public function getMinor()
+    {
+        return $this->verseg(1);
+    }
+
+    public function getPatch()
+    {
+        return $this->verseg(2);
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getPatchNotes()
+    {
+        return $this->notes;
+    }
+
+    public function toString()
+    {
+        return $this->tag;
+    }
+
+    public function matchesBand($current)
+    {
+        switch ($current) {
+        case "stable":
+            return $this->is_stable;
+        case "beta":
+            return $this->is_beta;
+        case "alpha":
+            return $this->is_alpha;
+        }
+    }
+
+    public function laterThan($maj, $min, $pat)
+    {
+        if ($this->getMajor() > $maj)
+            return true;
+
+        if ($this->getMajor() >= $maj &&
+            $this->getMinor() > $min)
+            return true;
+
+        if ($this->getMajor() >= $maj &&
+            $this->getMinor() >= $min &&
+            $this->getPatch() > $pat)
+            return true;
+
+        return false;
+    }
+
+    public function isDummy()
+    {
+        return !$this->laterThan(0, 0, 0);
+    }
+}
+
+/* Returns an array of Release objects parsed from the release API */
+function getReleases()
+{
+    Requests::register_autoloader();
+
+    $decoded = [];
+    try {
+        $json = Requests::get(RELEASES_ENDPOINT)->body;
+        $decoded = json_decode($json, true);
+    } catch (Exception $e) {
+        return [];
+    }
+
+    $obj = [];
+    foreach ($decoded as $d) {
+        $obj[] = new Release($d);
+    }
+
+    return $obj;
+}
 
 function getMajorVersion()
 {
@@ -115,36 +304,34 @@ function parseVersionString($version)
 
 function getLatestAvailableVersion($band)
 {
-    Requests::register_autoloader();
-
     $currentBand = getUpdateBand();
+    $releases = getReleases();
 
-    try {
-        $json = Requests::get(LATEST_UPDATE_ENDPOINT . $currentBand . ".json")->body;
-        $decoded = json_decode($json, true);
-    } catch (Requests_Exception $e) {
-        return "0.0.0";
+    global $dummy_release;
+    $latest = new Release($dummy_release);
+
+    foreach ($releases as $r) {
+        if ($r->matchesBand($currentBand) &&
+            $r->laterThan(getMajorVersion(),
+                            getMinorVersion(),
+                            getPatchVersion()) &&
+            $r->laterThan($latest)) {
+
+            $latest = $r;
+        }
     }
 
-    $version = $decoded["latest"];
-    return $version;
+    return $latest;
 }
 
 function isUpdateAvailable()
 {
     $currentVersion = getVersionString();
-    $latest = getLatestAvailableVersion(getUpdateBand());
-
-    $versions = parseVersionString($latest);
-
-    if ((int)$versions[0] > (int)getMajorVersion()
-        || (int)$versions[1] > (int)getMinorVersion()
-        || (int)$versions[2] > (int)getPatchVersion()) {
-
-        return true;
-    } else {
-        return false;
-    }
+    $latest = getLatestAvailableVersion(getUpdateBand())->laterThan(
+        getMajorVersion(),
+        getMinorVersion(),
+        getPatchVersion()
+    );
 }
 
 function isInsiderBand()

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -20,6 +20,7 @@ require ABSPATH . INC . "vendor/requests/library/Requests.php";
 
 
 define("LATEST_UPDATE_ENDPOINT", "https://dsjas.github.io/update/DSJAS/latest-");
+define("ARCHIVE_ENDPOINT", "https://github.com/DSJAS/DSJAS/archive");
 
 
 static $__version_information;
@@ -157,6 +158,10 @@ function isInsiderBand()
     return true;
 }
 
+function getArchiveLocation($major, $minor, $patch, $band)
+{
+    return sprintf("%s/%d.%d.%d-%s.tar.gz", ARCHIVE_ENDPOINT, $major, $minor, $patch, $band);
+}
 
 function loadVersionInfo()
 {

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -242,6 +242,19 @@ class Release
     {
         return !$this->laterThan(0, 0, 0);
     }
+
+    public function getDownload($band)
+    {
+        if ($band == "stable" && $this->is_stable) {
+            return $this->stable_zip;
+        } elseif ($band == "beta" && $this->is_beta) {
+            return $this->beta_zip;
+        } elseif ($band == "alpha" && $this->is_alpha) {
+            return $this->alpha_zip;
+        } else {
+            return false;
+        }
+    }
 }
 
 /* Returns an array of Release objects parsed from the release API */

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -292,16 +292,12 @@ function getPatchVersion()
 
 function getVersionName()
 {
-    $info = loadVersionInfo();
-
-    return $info["version-name"];
+    return getCurrentRelease()->getName();
 }
 
 function getVersionDescription()
 {
-    $info = loadVersionInfo();
-
-    return $info["version-description"];
+    return getCurrentRelease()->getPatchNotes();
 }
 
 function getUpdateBand()

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -331,7 +331,7 @@ function getCurrentRelease()
         if ($r->getMajor() == getMajorVersion() &&
             $r->getMinor() == getMinorVersion() &&
             $r->getPatch() == getPatchVersion() &&
-            $r->getBand() == getUpdateBand()) {
+            $r->matchesBand(getUpdateBand())) {
 
 
             /* cache results */

--- a/public/include/Update.php
+++ b/public/include/Update.php
@@ -121,12 +121,20 @@ class Release
 
     private function processPatchNotes($notes)
     {
-        $work = str_replace("\r\n", "<br>", $notes);
+        /* proper line endings */
+        $work = str_replace("\r\n", "\n<br>\n", $notes);
 
-        /* TODO: Header support (will need regex) */
-        /* $work = str_replace("#", "<h4>", $work); */
-        /* $work = str_replace("##", "<h5>", $work); */
-        /* $work = str_replace("###", "<h6>", $work); */
+        /* blockquotes */
+        $work = preg_replace("/\n> (.*)\n<br>\n/", '<blockquote>${1}</blockquote>', $work);
+
+        /* headers */
+        $work = preg_replace("/\n###(.*)\n<br>\n/", '<strong>${1}</strong>', $work);
+        $work = preg_replace("/\n##(.*)\n<br>\n/", '<h5>${1}</h5>', $work);
+        $work = preg_replace("/\n?#(.*)\n<br>\n/", '<h5>${1}</h5>', $work);
+
+        /* embedded formatting */
+        $work = preg_replace("/\*\*([^\*]*)\*\*/", '<strong>${1}</strong>', $work);
+        $work = preg_replace("/``([^`]*)``/", '<code>${1}</code>', $work);
 
         return $work;
     }

--- a/public/include/Util.php
+++ b/public/include/Util.php
@@ -84,6 +84,55 @@ function recursiveDeleteDirectory($dir)
     }
 }
 
+function recurseCopy(
+    string $sourceDirectory,
+    string $destinationDirectory,
+    string $childFolder = ''
+) {
+    $directory = opendir($sourceDirectory);
+
+    if (is_dir($destinationDirectory) === false) {
+        mkdir($destinationDirectory);
+    }
+
+    if ($childFolder !== '') {
+        if (is_dir("$destinationDirectory/$childFolder") === false) {
+            mkdir("$destinationDirectory/$childFolder");
+        }
+
+        while (($file = readdir($directory)) !== false) {
+            if ($file === '.' || $file === '..') {
+                continue;
+            }
+
+            if (is_dir("$sourceDirectory/$file") === true) {
+                recurseCopy("$sourceDirectory/$file", "$destinationDirectory/$childFolder/$file");
+            } else {
+                copy("$sourceDirectory/$file", "$destinationDirectory/$childFolder/$file");
+            }
+        }
+
+        closedir($directory);
+
+        return;
+    }
+
+    while (($file = readdir($directory)) !== false) {
+        if ($file === '.' || $file === '..') {
+            continue;
+        }
+
+        if (is_dir("$sourceDirectory/$file") === true) {
+            recurseCopy("$sourceDirectory/$file", "$destinationDirectory/$file");
+        }
+        else {
+            copy("$sourceDirectory/$file", "$destinationDirectory/$file");
+        }
+    }
+
+    closedir($directory);
+}
+
 function dsjas_alert($title, $body = "", $style = "info", $dismissible = false, $appendCSS = "")
 {
     $alertClass = "alert alert-" . $style . " " . $appendCSS;

--- a/scripts/Package.py
+++ b/scripts/Package.py
@@ -114,7 +114,7 @@ def copyDefaultConfiguration(distName):
                     distName + "/src/Version.json")
 
 
-def updateVersionJSON(distName, majorVersion, minorVersion, patch, name, description, band):
+def updateVersionJSON(distName, majorVersion, minorVersion, patch, band):
     fileRead = open("dist/" + distName + "/src/Version.json", "r")
 
     jsonData = json.load(fileRead, strict=False)
@@ -122,8 +122,6 @@ def updateVersionJSON(distName, majorVersion, minorVersion, patch, name, descrip
     jsonData["version"]["major"] = majorVersion
     jsonData["version"]["minor"] = minorVersion
     jsonData["version"]["patch"] = patch
-    jsonData["version-name"] = name
-    jsonData["version-description"] = description
     jsonData["version-release-band"] = band
 
     fileRead.close()
@@ -134,14 +132,11 @@ def updateVersionJSON(distName, majorVersion, minorVersion, patch, name, descrip
 
 
 def createDummyVersion(distName):
-    jsonData = {"version": {}, "version-name": "",
-                "version-description": "", "version-release-band": ""}
+    jsonData = {"version": {}, "version-release-band": ""}
 
     jsonData["version"]["major"] = "1"
     jsonData["version"]["minor"] = "0"
     jsonData["version"]["patch"] = "0"
-    jsonData["version-name"] = ""
-    jsonData["version-description"] = ""
     jsonData["version-release-band"] = "alpha"
 
     fileWrite = open("dist/" + distName + "/src/Version.json", "w")
@@ -228,9 +223,6 @@ if __name__ == "__main__":
     versionMajor = ""
     versionMinor = ""
     patch = ""
-
-    versionName = ""
-    versionDesc = ""
     versionBand = ""
 
     print("[OK] Your package has been created")
@@ -249,10 +241,6 @@ if __name__ == "__main__":
 
     separator()
 
-    versionName = inputOrDefault(
-        input("Version name:"), initial='', default='Minor update')
-    versionDesc = inputOrDefault(
-        input("Version description:"), initial='', default='Minor improvement update')
     versionBand = inputOrDefault(
         input("Version band [alpha/beta/stable]:"), initial='', default='alpha')
 
@@ -264,7 +252,7 @@ if __name__ == "__main__":
 
     # Update version.json
     updateVersionJSON(distName, versionMajor, versionMinor,
-                      patch, versionName, versionDesc, versionBand)
+                      patch, versionBand)
 
     print("[OK] Finished writing configuration")
     separator()
@@ -274,8 +262,8 @@ if __name__ == "__main__":
 
     print("Version ID: " + versionMajor + "." +
           versionMinor + "." + patch + "-" + versionBand)
-    print("Version name: " + versionName)
-    print("Version description: " + versionDesc)
+
+    print("\n[i] As of v0.1.4, patch notes and version names are automatically fetched from the API")
 
     separator()
 

--- a/scripts/install/ver.json
+++ b/scripts/install/ver.json
@@ -4,7 +4,5 @@
         "minor": "0",
         "patch": "1"
     },
-    "version-name": "Latest stable",
-    "version-description": "Initial version",
     "version-release-band": "alpha"
 }


### PR DESCRIPTION
Finally implement an automatic updates system. Updates are now completed with simply the push of a button, rather than the several stages of error-prone config backups and other nonsense like that.

The auto update system basically does what the documentation used to recommend you do manually.

## Changelog

1. Release information is now fully pulled from the GitHub API and patch notes on GitHub are now authoritative on release naming and patch notes
2. GitHub release artifacts are now used to pull updated versions of DSJAS from GitHub
3. Ver.json no longer contains any authoritative information about the current version, making retroactive fixes to omissions or other stuff much easier
4. dsjas.github.io/update API is now **deprecated** in favor of GitHub's own APIs. This API will be removed entirely in the future so all requests go to 404
5. Release bands now behave much more sanely for beta users

---
Closes #72 